### PR TITLE
avoid unused attribute property

### DIFF
--- a/attributes/attribute_croppie_image/controller.php
+++ b/attributes/attribute_croppie_image/controller.php
@@ -34,7 +34,7 @@ class Controller extends AttributeTypeController
         $values = $this->getValues();
 
         if ($values) {
-            return DIR_REL . '/application/files/avatars/' . $values['fileName'];
+            return DIR_REL . '/application/files/avatars/' . $values['fileNameThumbnail'];
         }
     }
 


### PR DESCRIPTION
the fileName property was removed by https://github.com/Remo/concrete5-attribute-croppie-image/commit/076f8f79229b60a51ee73aa8f03afe68965dfbfa#diff-911ad91008fa084ad121a7286f200b78 - therefore the fileName property should not be used anymore.